### PR TITLE
Dev templates

### DIFF
--- a/flaskr/templates/auth/login.html
+++ b/flaskr/templates/auth/login.html
@@ -1,0 +1,18 @@
+<!--Tells Jinja that this template should replace the blocks from the base template -->
+{% extends 'base.html' %}
+<!-- Set the title block & then output the value of it into the header block,
+  so that both window and page share the same title
+-->
+{% block header %}
+  <h1>{% block title %}Log In{% endblock %}</h1>
+{% endblock %}
+
+{% block content %}
+  <form method="post">
+    <label for="username">Username</label>
+    <input name="username" id="username" required>
+    <label for="password">Password</label>
+    <input type="password" name="password" id="password" required>
+    <input type="submit" value="Log In">
+  </form>
+{% endblock %}

--- a/flaskr/templates/auth/register.html
+++ b/flaskr/templates/auth/register.html
@@ -1,0 +1,18 @@
+<!--Tells Jinja that this template should replace the blocks from the base template -->
+{% extends 'base.html' %}
+<!-- Set the title block & then output the value of it into the header block,
+  so that both window and page share the same title
+-->
+{% block header %}
+  <h1>{% block title %}Register{% endblock %}</h1>
+{% endblock %}
+
+{% block content %}
+  <form method="post">
+    <label for="username">Username</label>
+    <input name="username" id="username" required>
+    <label for="password">Password</label>
+    <input type="password" name="password" id="password" required>
+    <input type="submit" value="Register">
+  </form>
+{% endblock %}

--- a/flaskr/templates/base.html
+++ b/flaskr/templates/base.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<!-- Change the title displayed in the browser’s tab and window title in other
+  templates
+-->
+<title>{% block title %}{% endblock %} - Flaskr</title>
+<link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+<nav>
+  <h1>Flaskr</h1>
+  <ul>
+    <!-- g is automaticaly  available in templates. 
+      Based on if g.user is set (from load_logged_in_user), either the username 
+      and a log out link are displayed, otherwise links to register and log in 
+      are displayed.  url_for() is also automatically available, and is used to 
+      generate URLs to views instead of writing them out manually.
+    -->
+    {% if g.user %}
+      <li><span>{{ g.user['username'] }}</span></li>
+      <li><a href="{{ url_for('auth.logout') }}">Log Out</a></li>
+    {% else %}
+      <li><a href="{{ url_for('auth.register') }}">Register</a></li>
+      <li><a href="{{ url_for('auth.login') }}">Log In</a></li>
+    {% endif %}
+  </ul>
+</nav>
+<section class="content">
+  <header>
+    <!--  Change the header displayed in the browser’s tab and window title
+      in other templates
+    -->
+    {% block header %}{% endblock %}
+  </header>
+  <!-- After the page title, and before the content, the template loops over each message
+    returned by get_flashed_messages(). flash() is used in the views to show error messages, 
+    and this is the code that will display them.
+  -->
+  {% for message in get_flashed_messages() %}
+    <div class="flash">{{ message}}</div>
+  {% endfor %}
+  <!--  Change the content of each page in the browser’s tab and window title
+      in other templates
+    -->
+  {% block content %}{% endblock %}
+</section>


### PR DESCRIPTION
#### What does this PR do?
Adds HTML templates for 
*  Base layout template - #2
* User Registration  `/auth/register` endpoint. - #3
* User log in `/auth/login` endpoint. - #4

#### Description of Task to be completed?
* Register a user and dtore the user details into a database
#### How the app should be tested 
* Install and set-up [Python3](https://www.python.org/downloads/)
* Install and set up a [pipenv & virtual environments](http://docs.python-guide.org/en/latest/dev/virtualenvs/)
* Install and set-up [git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) Version control
On a web browswer 
* [Download](https://github.com/artorious/flask_dojo/archive/master.zip) the repo as a zip folder
* Extract `flask_dojo` directory and navigate into it, 
OR
* Clone `git clone  https://github.com/artorious/flask_dojo.git`
* Navigate to repo's root folder `cd flask_dojo/`
* Install & setup the project's dependancies and requirements 
`$ pipenv shell`
* Setup Flask server
`$ export FLASK_A
PP=flaskr`
`$ export FLASK_ENV=development`
`$ flask run`
* On a web browswer navigate to [http://127.0.0.1:5000/auth/register.](http://127.0.0.1:5000/auth/register)

Try clicking the “Register” button without filling out the form and see that the browser shows an error message. Try removing the `required` attributes from the `register.html` template and click “Register” again. Instead of the browser showing an error, the page will reload and the error from `flash()` in the view will be shown.

Fill out a username and password and you’ll be redirected to the login page. Try entering an incorrect username, or the correct username and incorrect password. If you log in you’ll get an error because there’s no index view to redirect to yet.

#### Screenshots 

![1](https://user-images.githubusercontent.com/15730750/42423877-d0af4fd6-830a-11e8-8344-c562e78de03d.png)
![2](https://user-images.githubusercontent.com/15730750/42423878-d109d690-830a-11e8-9dfc-ad05ca075cce.png)

