### PR TITLE
Add CSS(styling) to the base template layout

### DIFF
--- a/flaskr/static/style.css
+++ b/flaskr/static/style.css
@@ -1,0 +1,131 @@
+html { 
+    font-family: sans-serif; 
+    background: #eee; 
+    padding: 1rem; 
+}
+
+body { 
+    max-width: 960px; 
+    margin: 0 auto; 
+    background: white; 
+}
+
+h1 { 
+    font-family: serif; 
+    color: #377ba8; 
+    margin: 1rem 0; 
+}
+
+a { 
+    color: #377ba8; 
+}
+
+hr { 
+    border: none; 
+    border-top: 1px solid lightgray; 
+}
+
+nav { 
+    background: lightgray; 
+    display: flex; 
+    align-items: center; 
+    padding: 0 0.5rem; 
+}
+
+nav h1 { 
+    flex: auto; 
+    margin: 0; 
+}
+
+nav h1 a { 
+    text-decoration: none; 
+    padding: 0.25rem 0.5rem; 
+}
+
+nav ul  { 
+    display: flex; 
+    list-style: none; 
+    margin: 0; 
+    padding: 0; 
+}
+
+nav ul li a, nav ul li span, header .action { 
+    display: block; 
+    padding: 0.5rem; 
+}
+.content { 
+    padding: 0 1rem 1rem; 
+}
+
+.content > header { 
+    border-bottom: 1px solid lightgray; 
+    display: flex; 
+    align-items: flex-end; 
+}
+
+.content > header h1 { 
+    flex: auto; 
+    margin: 1rem 0 0.25rem 0; 
+}
+
+.flash { 
+    margin: 1em 0; 
+    padding: 1em; 
+    background: #cae6f6; 
+    border: 1px solid #377ba8; 
+}
+
+.post > header { 
+    display: flex; 
+    align-items: flex-end; 
+    font-size: 0.85em; 
+}
+
+.post > header > div:first-of-type { 
+    flex: auto; 
+}
+
+.post > header h1 { 
+    font-size: 1.5em; 
+    margin-bottom: 0; 
+}
+
+.post .about { 
+    color: slategray; 
+    font-style: italic; 
+}
+
+.post .body { 
+    white-space: pre-line; 
+}
+
+.content:last-child { 
+    margin-bottom: 0; 
+}
+
+.content form { 
+    margin: 1em 0; 
+    display: flex; 
+    flex-direction: column; 
+}
+
+.content label { 
+    font-weight: bold; 
+    margin-bottom: 0.5em; 
+}
+
+.content input, .content textarea { 
+    margin-bottom: 1em; 
+}
+
+.content textarea { 
+    min-height: 12em; resize: vertical; 
+}
+
+input.danger { 
+    color: #cc2f2e; 
+}
+
+input[type=submit] { 
+    align-self: start; min-width: 10em; 
+}


### PR DESCRIPTION
#### What does this PR do?
Adds CSS to style the authentication views and templates templates for 
* User Registration  `/auth/register` endpoint.
* User log in `/auth/login` endpoint.

#### Description of Task to be completed?
 Adds a static CSS file. Flask automatically adds a static view that takes a path relative to the `flaskr/static` directory and serves it. The `base.html` template already has a link to the `style.css` file

#### How the app should be tested 
* Install and set-up [Python3](https://www.python.org/downloads/)
* Install and set up a [pipenv & virtual environments](http://docs.python-guide.org/en/latest/dev/virtualenvs/)
* Install and set-up [git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) Version control
On a web browser 
* [Download](https://github.com/artorious/flask_dojo/archive/master.zip) the repo as a zip folder
* Extract `flask_dojo` directory and navigate into it, 
OR
* Clone `git clone  https://github.com/artorious/flask_dojo.git`
* Navigate to repo's root folder `cd flask_dojo/`
* Checkout the Static files branch `$ git checkout dev-static-files`
* Install & set-up the project's dependencies and requirements 
`$ pipenv shell`
* Setup Flask server
`$ export FLASK_APP=flaskr`
`$ export FLASK_ENV=development`
`$ flask init-db` One-time command (The first time on any machine)
`$ flask run`
* On a web browser navigate to [http://127.0.0.1:5000/auth/register.](http://127.0.0.1:5000/auth/register)
* On a web browser navigate to [http://127.0.0.1:5000/auth/login.](http://127.0.0.1:5000/auth/login)

#### Screen-shots 

![3](https://user-images.githubusercontent.com/15730750/42432909-96d45d24-8355-11e8-83cc-b40f7f384066.png)
![4](https://user-images.githubusercontent.com/15730750/42432910-973930dc-8355-11e8-90ae-a1cf432326f6.png)



